### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged
-
 npm run build && git add dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -8410,7 +8410,7 @@
     "actions-toolkit": {
       "version": "git+ssh://git@github.com/nearform/actions-toolkit.git#98deb7af9c6c47d6cb06a0bd1605ad783a998294",
       "integrity": "sha512-sohRDG9zsq2PmDRxq0Ff9wfipaHPP5/NvYowSW7TI5AuXOBno9YOpeLMk7q9wa0s7wVIlGx0N0W8YntJ6zYeLw==",
-      "from": "actions-toolkit@github:nearform/actions-toolkit#98deb7af9c6c47d6cb06a0bd1605ad783a998294",
+      "from": "actions-toolkit@github:nearform/actions-toolkit",
       "requires": {
         "@actions/core": "^1.10.1"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "tap --no-coverage",
-    "prepare": "husky install",
+    "prepare": "husky",
     "build": "ncc build src --license licenses.txt"
   },
   "repository": {


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)